### PR TITLE
docs: 修正 cc-switch 仓库链接（super-l → farion1231，原链接 404）

### DIFF
--- a/PROMO.md
+++ b/PROMO.md
@@ -59,7 +59,7 @@ docker run -d \
 ### 🛠️ 常见开发工具配置（支持任意可配 Base URL 的工具）
 
 * **Cursor**：`Settings` → `Models` → `OpenAI Base URL` 改为 `http://127.0.0.1:18701/v1`
-* **Claude Code**：使用 **[cc-switch](https://github.com/super-l/cc-switch)** 将 Base URL 切换为 `http://127.0.0.1:18703`，或终端运行 `export ANTHROPIC_BASE_URL="http://127.0.0.1:18703"`
+* **Claude Code**：使用 **[cc-switch](https://github.com/farion1231/cc-switch)** 将 Base URL 切换为 `http://127.0.0.1:18703`，或终端运行 `export ANTHROPIC_BASE_URL="http://127.0.0.1:18703"`
 * **Codex / Pi / OpenCode / 命令行工具**：
   ```bash
   export OPENAI_BASE_URL="http://127.0.0.1:18701/v1"

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@
 - 填入你的真实 API Key（Maskit 在本地收到后安全转发给上游）。
 
 ### 2. Claude Code（配合 cc-switch 一键使用）
-- 在 **[cc-switch](https://github.com/super-l/cc-switch)** 中，将正在使用的 Claude 渠道 **Base URL** 修改为：
+- 在 **[cc-switch](https://github.com/farion1231/cc-switch)** 中，将正在使用的 Claude 渠道 **Base URL** 修改为：
   `http://127.0.0.1:18703`
 - 或通过终端环境变量启动：
   ```bash

--- a/README_EN.md
+++ b/README_EN.md
@@ -106,7 +106,7 @@ Go to `Settings` → `Models`:
 - Enter your API Key (Maskit forwards it securely to upstream).
 
 ### 2. Claude Code (with cc-switch)
-- In **[cc-switch](https://github.com/super-l/cc-switch)**, set the Claude channel **Base URL** to:
+- In **[cc-switch](https://github.com/farion1231/cc-switch)**, set the Claude channel **Base URL** to:
   `http://127.0.0.1:18703`
 - Or launch from terminal:
   ```bash

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -160,7 +160,7 @@ docker run -d \
 
 ### 2. Claude Code 接入（结合 cc-switch 最简单）
 
-如果你平时使用社区广受好评的多渠道切换工具 **[cc-switch](https://github.com/super-l/cc-switch)**：
+如果你平时使用社区广受好评的多渠道切换工具 **[cc-switch](https://github.com/farion1231/cc-switch)**：
 
 1. 打开 `cc-switch` 客户端，找到你正在使用的 Claude 渠道；
 2. 点击编辑，将 **Base URL** 直接修改为 Maskit 的本地 Anthropic 端口：


### PR DESCRIPTION
### 改动说明 / What does this PR do?

文档里 cc-switch 的链接指向 `github.com/super-l/cc-switch`，该仓库 **返回 404**。实际仓库是 [`github.com/farion1231/cc-switch`](https://github.com/farion1231/cc-switch)。本 PR 把 4 处链接统一改过来，不改动任何文案。

验证：

```
$ curl -s -o /dev/null -w "%{http_code}" https://github.com/super-l/cc-switch
404
$ curl -s -o /dev/null -w "%{http_code}" https://github.com/farion1231/cc-switch
200
```

补充佐证：本机安装的 CC Switch 客户端 bundle id 为 `com.ccswitch.desktop`，与 `farion1231/cc-switch` 的 `src-tauri/tauri.conf.json` 一致；其功能（多渠道切换、每个渠道可自定义 Base URL）也正是文档描述的接入方式。

涉及文件：`README.md:109`、`README_EN.md:109`、`PROMO.md:62`、`docs/TUTORIAL.md:163`

### 影响范围 / Scope
- [ ] 脱敏/还原引擎（`engine/transparent.py`）—— 已跑 `python tests/smoke_stream.py`
- [ ] 控制面 / API（`engine/panel.py`）
- [ ] 前端界面 —— 中英文文案都已补齐
- [ ] 桌面壳（`src-tauri/`）—— 已跑 `cargo test --lib`
- [ ] 打包 / Docker / CI
- [x] 仅文档

### 自检 / Checklist
- [x] 未提交任何真实密钥、内网地址、个人数据（含测试样例）
- [x] 未新增任何对外网络请求（本项目承诺零遥测；如确需新增，已在 SECURITY.md「出站清单」登记）
- [x] 提交信息符合 Conventional Commits（`feat:` / `fix:` / `docs:` …）
- [x] 我确认所提交的代码为本人原创，并遵循本项目开源协议
