### PR TITLE
fix: collect usage across Anthropic and Responses SSE events

### DIFF
--- a/engine/panel.py
+++ b/engine/panel.py
@@ -45,6 +45,8 @@ from shield_defaults import (
     OPENROUTER_MODELS_URL,
     PRICE_SYNC_INTERVAL_DAYS,
     MODEL_PRICES,
+    extract_usage,
+    SSEUsageAccumulator,
 )
 
 # 资源目录（打包后随 exe 发布的只读资源：templates、transparent.py、shield_defaults.py）
@@ -973,6 +975,9 @@ def _make_passthrough_handler(target, proxy_url=None, upstream_name=None):
                 # 几十~几百字节永远攒不满 64KB → 客户端等整个生成结束才见首字节
                 # （实测 read=2.0s 一次性返回 vs read1=0s 逐块返回）。
                 sent = 0
+                usage_stream = (SSEUsageAccumulator()
+                                if "text/event-stream" in resp.getheader("Content-Type", "").lower()
+                                else None)
                 resp_tail_chunks = []
                 tail_len = 0
                 while True:
@@ -984,22 +989,29 @@ def _make_passthrough_handler(target, proxy_url=None, upstream_name=None):
                     sent += len(chunk)
                     self.wfile.write(chunk)
                     self.wfile.flush()
-                    # 留存尾部 chunk（用于提取 usage 计费，最大 64KB）
-                    resp_tail_chunks.append(chunk)
-                    tail_len += len(chunk)
-                    if tail_len > 65536:
+                    if usage_stream is not None:
+                        # 用量逐行累计，避免长流把 message_start 的输入计数挤出尾部。
+                        try:
+                            usage_stream.feed(chunk)
+                        except Exception:
+                            pass  # 计费解析失败不影响原样转发
+                    else:
+                        # 非 SSE 响应仍只留存尾部，最大 64KB。
+                        resp_tail_chunks.append(chunk)
+                        tail_len += len(chunk)
                         while tail_len > 65536 and resp_tail_chunks:
                             tail_len -= len(resp_tail_chunks.pop(0))
                 self.wfile.flush()
-                # 尝试从尾部文本提取 token usage（供首屏 Token 与费用估算）
-                resp_usage = {}
-                if resp_tail_chunks:
-                    try:
-                        from shield_defaults import extract_usage
+                # SSE 保留独立的累计用量；兼容末行没有换行的上游。
+                resp_usage = usage_stream.usage if usage_stream is not None else {}
+                try:
+                    if usage_stream is not None:
+                        resp_usage = usage_stream.feed(b"", final=True)
+                    elif resp_tail_chunks:
                         tail_text = b"".join(resp_tail_chunks).decode("utf-8", errors="replace")
                         resp_usage = extract_usage(tail_text)
-                    except Exception:
-                        pass
+                except Exception:
+                    pass
                 # 透传期间记 PASS 事件：不脱敏时段的流量也要留痕
                 # （此前透传完全不记日志，用户无法确认流量经过了自己）
                 try:

--- a/engine/shield_defaults.py
+++ b/engine/shield_defaults.py
@@ -457,36 +457,71 @@ def save_price_cache(path, prices, source):
         pass
 
 
-def extract_usage(body_text):
+def extract_usage(body_text, previous=None):
     """从响应 body 提取 token 用量（尽力而为，供统计与费用估算）。
 
     支持三种形态：
     - OpenAI chat/completions 非流式：顶层 usage.{prompt_tokens,completion_tokens}
     - Anthropic messages：usage.{input_tokens,output_tokens}
-    - SSE 流式：usage 在最后一个带 usage 的 chunk（客户端须带 include_usage，
-      否则上游不返回，采不到属正常）。SSE 拼接文本里逐行扫 data: 取最后命中。
+    - SSE：包括 message_start.message.usage 和 response.* 的 response.usage。
+      用量是累计计数：只更新本次出现的字段，不相加，也不把缺失字段清零。
+    previous 可传入此前流片段的结果；文本截断不影响跨片段累计。
     返回 {"prompt_tokens": int, "completion_tokens": int} 或 {}（没采到）。
     """
-    if not body_text:
-        return {}
     import json
+    usage = dict(previous or {})
+
+    def merge(data):
+        if not isinstance(data, dict):
+            return
+        u = data.get("usage")
+        if not isinstance(u, dict) or not u:
+            if data.get("type") == "message_start":
+                envelope = data.get("message")
+            elif str(data.get("type", "")).startswith("response."):
+                envelope = data.get("response")
+            else:
+                envelope = data.get("meta")
+            if isinstance(envelope, dict):
+                u = envelope.get("usage") or envelope.get("tokens")
+        if not isinstance(u, dict):
+            return
+        updates = {}
+        for field, aliases in (("prompt_tokens", ("prompt_tokens", "input_tokens")),
+                               ("completion_tokens", ("completion_tokens", "output_tokens"))):
+            for alias in aliases:
+                if alias not in u:
+                    continue
+                try:
+                    value = int(u[alias])
+                except (TypeError, ValueError, OverflowError):
+                    continue
+                if value >= 0:
+                    updates[field] = value
+                    break
+        # Preserve the existing total-only compatibility path.
+        if not updates and u.get("total_tokens") is not None:
+            try:
+                total = int(u["total_tokens"])
+                if total >= 0:
+                    updates["prompt_tokens"] = total
+            except (TypeError, ValueError, OverflowError):
+                pass
+        if updates:
+            usage.update(updates)
+            usage.setdefault("prompt_tokens", 0)
+            usage.setdefault("completion_tokens", 0)
+
+    if not body_text:
+        return usage
     try:
         data = json.loads(body_text)
-        if isinstance(data, dict):
-            u = data.get("usage") or {}
-            if not u and isinstance(data.get("meta"), dict):
-                u = data["meta"].get("tokens") or {}
-            if isinstance(u, dict):
-                p = int(u.get("prompt_tokens") or u.get("input_tokens") or 0)
-                c = int(u.get("completion_tokens") or u.get("output_tokens") or 0)
-                if not p and not c and u.get("total_tokens"):
-                    p = int(u["total_tokens"])
-                if p or c:
-                    return {"prompt_tokens": p, "completion_tokens": c}
-    except Exception:
+    except (TypeError, ValueError):
         pass
-    # SSE：扫所有 data: 行，取最后带 usage 的 chunk（OpenAI 流式惯例）
-    last = {}
+    else:
+        merge(data)
+        return usage
+    # SSE data lines may contain partial usage snapshots from different events.
     for line in body_text.splitlines():
         if not line.startswith("data:"):
             continue
@@ -497,14 +532,5 @@ def extract_usage(body_text):
             d = json.loads(line_data)
         except Exception:
             continue
-        if not isinstance(d, dict):
-            continue
-        u = d.get("usage")
-        if not isinstance(u, dict):
-            continue
-        p = int(u.get("prompt_tokens") or u.get("input_tokens") or 0)
-        c = int(u.get("completion_tokens") or u.get("output_tokens") or 0)
-        if p or c:
-            last = {"prompt_tokens": p, "completion_tokens": c}
-    return last
-
+        merge(d)
+    return usage

--- a/engine/shield_defaults.py
+++ b/engine/shield_defaults.py
@@ -499,8 +499,8 @@ def extract_usage(body_text, previous=None):
                 if value >= 0:
                     updates[field] = value
                     break
-        # Preserve the existing total-only compatibility path.
-        if not updates and u.get("total_tokens") is not None:
+        # Preserve total-only snapshots, including explicit zero breakdowns.
+        if not any(updates.values()) and u.get("total_tokens") is not None:
             try:
                 total = int(u["total_tokens"])
                 if total >= 0:
@@ -534,3 +534,35 @@ def extract_usage(body_text, previous=None):
             continue
         merge(d)
     return usage
+
+
+class SSEUsageAccumulator:
+    """Merge usage from complete SSE data lines without retaining response text.
+
+    Network chunks can split a JSON line anywhere. Oversized lines are skipped
+    until the next newline, keeping this best-effort accounting buffer bounded.
+    """
+
+    MAX_LINE_BYTES = 65536
+
+    def __init__(self):
+        self.usage = {}
+        self._pending = b""
+        self._discard_line = False
+
+    def feed(self, chunk, final=False):
+        parts = chunk.split(b"\n")
+        for index, part in enumerate(parts):
+            if not self._discard_line:
+                if len(self._pending) + len(part) <= self.MAX_LINE_BYTES:
+                    self._pending += part
+                else:
+                    self._pending = b""
+                    self._discard_line = True
+            if index < len(parts) - 1 or final:
+                if not self._discard_line and self._pending.startswith(b"data:"):
+                    self.usage = extract_usage(
+                        self._pending.decode("utf-8", errors="replace"), previous=self.usage)
+                self._pending = b""
+                self._discard_line = False
+        return self.usage

--- a/engine/transparent.py
+++ b/engine/transparent.py
@@ -3376,7 +3376,7 @@ def _sse_stream_factory(flow, sid, host, method, emit_path, source):
         "text": [],       # 还原后文本留存（供审计/扫描），有上限
         "text_len": 0,
         "truncated": False,  # 文本留存已达上限，后续块不再累积
-        "usage": {},      # 最后一次采到的 token 用量（与文本留存解耦，见 _keep）
+        "usage": {},      # 累计 token 用量，保留未再次上报的字段（与文本留存解耦）
         "done": False,
         "calls": 0,       # 诊断：stream 回调被调用次数
         "bytes_in": 0,    # 诊断：累计输入字节
@@ -3387,7 +3387,7 @@ def _sse_stream_factory(flow, sid, host, method, emit_path, source):
         # （实测单次 completion 达 1 万+ token）会把带 usage 的尾部整个丢掉，
         # 「今日 Token 用量」永久少计。因此 usage 每块单独扫，不受留存上限影响。
         try:
-            u = _extract_usage(chunk)
+            u = _extract_usage(chunk, previous=state["usage"])
             if u:
                 state["usage"] = u
         except Exception:

--- a/tests/test_stream_usage.py
+++ b/tests/test_stream_usage.py
@@ -1,0 +1,77 @@
+"""Usage snapshots from supported SSE protocols must merge without double counting."""
+import json
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "engine"))
+import shield_defaults as defaults
+import transparent as tr
+
+
+def event(data):
+    return "data: " + json.dumps(data) + "\n\n"
+
+
+class StreamingUsageTests(unittest.TestCase):
+    def test_anthropic_snapshots_merge_without_summing_cumulative_counts(self):
+        start = {"type": "message_start", "message": {"usage": {"input_tokens": 25, "output_tokens": 1}}}
+        updates = [{"type": "message_delta", "usage": {"output_tokens": n}} for n in (10, 15)]
+        text = "".join(event(d) for d in [start, *updates])
+        expected = {"prompt_tokens": 25, "completion_tokens": 15}
+        self.assertEqual(defaults.extract_usage(text), expected)
+        usage = {}
+        for data in [start, *updates]:
+            usage = defaults.extract_usage(event(data), previous=usage)
+        self.assertEqual(usage, expected)
+
+    def test_response_terminal_events_and_existing_json_shapes(self):
+        expected = {"prompt_tokens": 37, "completion_tokens": 11}
+        for kind in ("response.completed", "response.incomplete", "response.failed"):
+            with self.subTest(kind=kind):
+                data = {"type": kind, "response": {"usage": {"input_tokens": 37, "output_tokens": 11}}}
+                self.assertEqual(defaults.extract_usage(event(data)), expected)
+        for data in ({"usage": expected}, {"usage": {"input_tokens": 37, "output_tokens": 11}},
+                     {"meta": {"tokens": expected}}, {"usage": {}, "meta": {"tokens": expected}}):
+            with self.subTest(data=data):
+                self.assertEqual(defaults.extract_usage(json.dumps(data)), expected)
+        self.assertEqual(defaults.extract_usage('{"usage":{"total_tokens":128}}'),
+                         {"prompt_tokens": 128, "completion_tokens": 0})
+
+    def test_invalid_fields_do_not_erase_usage_and_explicit_zero_is_valid(self):
+        previous = {"prompt_tokens": 25, "completion_tokens": 15}
+        for bad in (None, "not-a-count", -1, float("inf")):
+            with self.subTest(bad=bad):
+                data = {"usage": {"input_tokens": bad, "output_tokens": 0}}
+                self.assertEqual(defaults.extract_usage(event(data), previous),
+                                 {"prompt_tokens": 25, "completion_tokens": 0})
+        self.assertEqual(previous, {"prompt_tokens": 25, "completion_tokens": 15})
+        self.assertEqual(defaults.extract_usage("data: [DONE]\n\n", previous), previous)
+
+    def test_stream_callback_keeps_usage_after_text_truncation_and_network_splits(self):
+        sid = "usage-test"
+        tr._new_session(sid)
+        self.addCleanup(tr.sessions.pop, sid, None)
+        flow = SimpleNamespace(metadata={})
+        with mock.patch.object(tr, "_SSE_KEEP_MAX", 1), \
+             mock.patch.object(tr, "_emit_restore_summary") as summary, \
+             mock.patch.object(tr, "_audit_response"), \
+             mock.patch.object(tr, "_scan_response"), \
+             mock.patch.object(tr, "_emit") as emit:
+            stream = tr._sse_stream_factory(flow, sid, "example.invalid", "POST", "/v1/messages", {})
+            data = [
+                {"type": "message_start", "message": {"usage": {"input_tokens": 25, "output_tokens": 1}}},
+                {"type": "content_block_delta", "index": 0, "delta": {"text": "test" * 100}},
+                {"type": "message_delta", "usage": {"output_tokens": 15}},
+                {"type": "message_stop"},
+            ]
+            raw = "".join(event(d) for d in data).encode()
+            for offset in range(0, len(raw), 17):
+                stream(raw[offset:offset + 17])
+            stream(b"")
+        emit.assert_not_called()
+        summary.assert_called_once()
+        self.assertEqual(summary.call_args.kwargs["stream_usage"],
+                         {"prompt_tokens": 25, "completion_tokens": 15})

--- a/tests/test_stream_usage.py
+++ b/tests/test_stream_usage.py
@@ -1,4 +1,5 @@
 """Usage snapshots from supported SSE protocols must merge without double counting."""
+import io
 import json
 import sys
 import unittest
@@ -8,6 +9,7 @@ from unittest import mock
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "engine"))
 import shield_defaults as defaults
+import panel
 import transparent as tr
 
 
@@ -74,4 +76,66 @@ class StreamingUsageTests(unittest.TestCase):
         emit.assert_not_called()
         summary.assert_called_once()
         self.assertEqual(summary.call_args.kwargs["stream_usage"],
+                         {"prompt_tokens": 25, "completion_tokens": 15})
+
+    def test_total_fallback_with_zero_fields_remains_compatible(self):
+        for fields in ({"completion_tokens": 0}, {"prompt_tokens": 0},
+                       {"input_tokens": 0, "output_tokens": 0}):
+            with self.subTest(fields=fields):
+                data = {"usage": {"total_tokens": 128, **fields}}
+                self.assertEqual(defaults.extract_usage(json.dumps(data)),
+                                 {"prompt_tokens": 128, "completion_tokens": 0})
+        self.assertEqual(defaults.extract_usage(event({"usage": {
+            "total_tokens": 128, "prompt_tokens": 100, "completion_tokens": 28}})),
+            {"prompt_tokens": 100, "completion_tokens": 28})
+
+    def forward_response(self, raw, content_type, chunk_size):
+        handler_type = panel._make_passthrough_handler("https://example.invalid")
+        handler = object.__new__(handler_type)
+        handler.headers = {}
+        handler.rfile = io.BytesIO()
+        handler.wfile = io.BytesIO()
+        handler.client_address = ("127.0.0.1", 12345)
+        handler.path = "/v1/messages"
+        handler.command = "POST"
+        for name in ("send_response", "send_header", "end_headers", "send_error"):
+            setattr(handler, name, mock.Mock())
+        headers = {"Content-Type": content_type, "Content-Length": str(len(raw))}
+        response = mock.Mock(status=200)
+        response.getheader.side_effect = lambda name, default=None: headers.get(name, default)
+        response.getheaders.return_value = list(headers.items())
+        response.read1.side_effect = [raw[i:i + chunk_size] for i in range(0, len(raw), chunk_size)] + [b""]
+        with mock.patch.object(panel.http.client, "HTTPSConnection") as connection, \
+             mock.patch.object(panel, "enqueue_event") as enqueue:
+            connection.return_value.getresponse.return_value = response
+            handler._do_forward()
+        handler.send_error.assert_not_called()
+        connection.return_value.close.assert_called_once()
+        self.assertEqual(handler.wfile.getvalue(), raw)
+        enqueue.assert_called_once()
+        self.assertEqual(enqueue.call_args.args[0]["type"], "PASS")
+        return enqueue.call_args.args[0]["usage"]
+
+    def test_passthrough_keeps_initial_usage_in_long_split_stream(self):
+        start = {"type": "message_start", "message": {"usage": {"input_tokens": 25, "output_tokens": 1}}}
+        content = {"type": "content_block_delta", "index": 0, "delta": {"text": "test" * 300}}
+        end = {"type": "message_delta", "usage": {"output_tokens": 15}}
+        raw = (event(start) + event(content) * 100 + event(end)).encode()
+        self.assertGreater(len(raw), 65536)
+        for size in (17, 65536):
+            with self.subTest(chunk_size=size):
+                self.assertEqual(self.forward_response(raw, "text/event-stream", size),
+                                 {"prompt_tokens": 25, "completion_tokens": 15})
+
+    def test_passthrough_skips_oversized_lines_and_recovers_usage_at_eof(self):
+        start = event({"type": "message_start", "message": {"usage": {"input_tokens": 25}}})
+        huge = event({"type": "content_block_delta", "delta": {"text": "x" * 100000}})
+        end = event({"type": "message_delta", "usage": {"output_tokens": 15}}).rstrip()
+        raw = (start + huge + end).replace("\n", "\r\n").encode()
+        self.assertEqual(self.forward_response(raw, "text/event-stream", 4096),
+                         {"prompt_tokens": 25, "completion_tokens": 15})
+
+    def test_passthrough_keeps_non_streaming_json_usage(self):
+        raw = json.dumps({"usage": {"prompt_tokens": 25, "completion_tokens": 15}}).encode()
+        self.assertEqual(self.forward_response(raw, "application/json", 17),
                          {"prompt_tokens": 25, "completion_tokens": 15})


### PR DESCRIPTION
### 改动说明 / What does this PR do?

有些流式响应已经返回用量，面板却少记了输入 token，或完全没有记录。Anthropic 的输入用量可以放在 `message_start.message.usage`，而 Responses 完成事件使用 `response.usage`；原来的解析只查看事件顶层 `usage`。

这次补齐了这些事件结构，并让流回调保留之前上报的字段。后续事件只含输出用量时，不再把输入清零；累计计数取最新值，避免重复相加。现有 Chat Completions、非流式 JSON 和 total-only 的兼容路径继续保留。

透传模式也会逐行累积 SSE 用量，因此长响应不会再把开头的输入计数挤出 64 KiB 尾部缓存。只保留用量和有上限的未完成行，不缓存整段响应；超长行跳过后仍能继续读取后续用量。`total_tokens` 与显式零值同时出现时，也保留原有的兼容换算。

### 影响范围 / Scope

- [x] 用量解析与流式响应统计
- [x] 脱敏/还原引擎，已跑流式冒烟

### 验证 / Validation

新增 8 项回归检查，覆盖 Anthropic 分阶段累计用量、Responses 终态事件、已有 JSON 格式、非法计数、零值与总计兼容，以及网络分片和文本留存截断。直接调用透传处理器验证超过 64 KiB 的响应、17 字节分片、超长行、CRLF 和末行无换行，并确认返回字节保持不变。

本地 macOS / Python 3.13：543 项单元测试通过；Python 编译检查、流式和出口代理冒烟、前端构建、Lint、中英文字典对齐及版本一致性检查均通过。使用模拟上游，未调用付费模型。

### 自检 / Checklist

- [x] 未提交真实密钥、内网地址或个人数据
- [x] 未新增对外网络请求
- [x] 提交信息符合 Conventional Commits
- [x] 遵循项目 AGPL-3.0 开源许可
