### PR TITLE
fix: avoid skipping events during incremental log polling

### DIFF
--- a/engine/event_store.py
+++ b/engine/event_store.py
@@ -1177,10 +1177,12 @@ def fetch_restore_items(now=None, limit=200):
 
 
 def fetch_events(since=0, limit=500, sensitive_only=False, query="", fulltext=False,
-                 event_type=None, max_limit=1000):
+                 event_type=None, max_limit=1000, ascending=False):
     """读取事件列表。
 
     since=id（返回 id>since 的，供增量轮询）；limit 约束返回条数；
+    ascending=True 按游标之后最早的记录分页，避免增量积压时跳过中间记录。
+    默认仍取最新记录，保持首次加载、导出和历史调用的语义。
     sensitive_only 隐藏 PASS/SKIP；query 搜索主机/路径/方法/状态/类型等结构化列。
     event_type 按事件类型精确过滤（下推到 SQL，命中 idx_events_type_ts）。
         它与 sensitive_only 互斥且优先级更高：显式指定类型时以类型为准，否则
@@ -1219,13 +1221,13 @@ def fetch_events(since=0, limit=500, sensitive_only=False, query="", fulltext=Fa
     sql = (
         "SELECT id, payload FROM events WHERE "
         + " AND ".join(where)
-        + " ORDER BY id DESC LIMIT ?"
+        + (" ORDER BY id ASC LIMIT ?" if ascending else " ORDER BY id DESC LIMIT ?")
     )
     params.append(limit)
     with closing(_connect()) as conn:
         conn.row_factory = sqlite3.Row
         rows = conn.execute(sql, params).fetchall()
-    return [_row_to_event(row) for row in reversed(rows)]
+    return [_row_to_event(row) for row in (rows if ascending else reversed(rows))]
 
 
 def prune_events(now=None, retention_days=RETENTION_DAYS):

--- a/engine/panel.py
+++ b/engine/panel.py
@@ -4314,7 +4314,7 @@ def api_logs():
         prune_event_log()
         _last_log_prune[0] = time.time()
     since = _arg_int("since", 0, 0, 2**31)
-    limit = _arg_int("limit", 500, 1, 5000)
+    limit = _arg_int("limit", 500, 1, 1000)
     # 默认显示全部事件（含 SKIP/PASS 噪声）。曾默认 '1' 隐藏，用户会误以为日志丢了。
     sensitive_only = request.args.get("sensitive", "0") != "0"
     query = request.args.get("q", "")
@@ -4324,8 +4324,15 @@ def api_logs():
     event_type = request.args.get("type", "").strip().upper() or None
     if event_type and not re.fullmatch(r"[A-Z_]{1,32}", event_type):
         event_type = None
-    ev = fetch_events(since=since, limit=limit, sensitive_only=sensitive_only,
-                      query=query, fulltext=fulltext, event_type=event_type)
+    # First load shows the latest page; subsequent polls consume the oldest unseen
+    # records. Fetch one extra row to tell the client whether it needs to catch up.
+    incremental = since > 0
+    ev = fetch_events(since=since, limit=limit + int(incremental), sensitive_only=sensitive_only,
+                      query=query, fulltext=fulltext, event_type=event_type,
+                      max_limit=1001, ascending=incremental)
+    has_more = incremental and len(ev) > limit
+    ev = ev[:limit]
+    next_since = ev[-1]["seq"] if ev else since
     # slim：剔除只有详情弹窗才用的正文字段。这四个字段占 events 体积 79%
     # （dialog 34% + dialog_req 28% + resp_preview 9% + req_preview 8%），
     # 而列表行一个都不渲染。全量 1000 条实测 8.2MB → slim 后约 1.7MB。
@@ -4382,6 +4389,8 @@ def api_logs():
         "db": str(DB_PATH),
         "sensitive_only": sensitive_only,
         "total": len(ev),
+        "has_more": has_more,
+        "next_since": next_since,
     })
 
 

--- a/frontend/src/api/logs.ts
+++ b/frontend/src/api/logs.ts
@@ -20,7 +20,7 @@ export interface LogsParams {
   slim?: boolean
 }
 
-export function getLogs(params: LogsParams): Promise<LogsResponse> {
+export function getLogs(params: LogsParams, signal?: AbortSignal): Promise<LogsResponse> {
   const search = new URLSearchParams()
   if (params.since) search.set('since', String(params.since))
   if (params.limit) search.set('limit', String(params.limit))
@@ -30,7 +30,7 @@ export function getLogs(params: LogsParams): Promise<LogsResponse> {
   if (params.fulltext) search.set('fulltext', '1')
   if (params.slim !== false) search.set('slim', '1')
   const qs = search.toString()
-  return shieldFetch<LogsResponse>(`/api/logs${qs ? `?${qs}` : ''}`)
+  return shieldFetch<LogsResponse>(`/api/logs${qs ? `?${qs}` : ''}`, { signal })
 }
 
 /** 单条事件全量（含 original/dialog 明文，仅详情弹窗调用） */

--- a/frontend/src/pages/Logs.tsx
+++ b/frontend/src/pages/Logs.tsx
@@ -141,26 +141,39 @@ export default function LogsPage() {
   )
   const logsQuery = useQuery<LogsCache>({
     queryKey: logsKey,
-    queryFn: async ({ queryKey }) => {
+    queryFn: async ({ queryKey, signal }) => {
       // 从缓存读上次的累积列表 + 游标（首次为空）
       const prev = queryClient.getQueryData<LogsCache>(queryKey)
       const prevList = prev?.list ?? []
-      const since = prevList.length > 0 ? prevList[prevList.length - 1].seq : 0
-      const resp = await getLogs({
-        since,
-        limit: 200,
-        type: filterType === FILTER_ALL ? undefined : filterType,
-        sensitive,
-        q,
-        fulltext,
-        slim: true,
-      })
-      if (resp.tail?.length) setTailData(resp.tail)
-      // 增量 append 去重（按 seq）
+      let since = prevList.length > 0 ? prevList[prevList.length - 1].seq : 0
+      let list = prevList
+      let tail = prev?.tail ?? []
       const seen = new Set(prevList.map((e) => e.seq))
-      const added = (resp.events as ShieldEvent[]).filter((e) => !seen.has(e.seq))
-      const list = added.length > 0 ? [...prevList, ...added] : prevList
-      return { list, tail: resp.tail ?? prev?.tail ?? [] }
+      // Catch up after backgrounding without skipping records. Bound each poll so
+      // sustained traffic cannot keep it running forever; the next poll continues.
+      for (let batch = 0; batch < 5; batch++) {
+        const resp = await getLogs({
+          since,
+          limit: 200,
+          type: filterType === FILTER_ALL ? undefined : filterType,
+          sensitive,
+          q,
+          fulltext,
+          slim: true,
+        }, signal)
+        tail = resp.tail ?? tail
+        const added = resp.events.filter((e) => {
+          if (seen.has(e.seq)) return false
+          seen.add(e.seq)
+          return true
+        })
+        if (added.length) list = [...list, ...added]
+        const next = resp.next_since ?? resp.events.at(-1)?.seq ?? since
+        if (!resp.has_more || next <= since) break
+        since = next
+      }
+      if (tail.length) setTailData(tail)
+      return { list, tail }
     },
     // 本页单独配置：不走全局 30s 缓存，挂载即发
     staleTime: 0,

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -154,6 +154,9 @@ export interface LogsResponse {
   db: string
   sensitive_only: boolean
   total: number
+  /** Older engines may not include pagination metadata. */
+  has_more?: boolean
+  next_since?: number
 }
 
 export interface LogDetailResponse {

--- a/tests/test_log_pagination.py
+++ b/tests/test_log_pagination.py
@@ -1,0 +1,83 @@
+"""A log poll must not skip the oldest unseen events when a page fills."""
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "engine"))
+import event_store
+import panel
+
+
+class LogPaginationTests(unittest.TestCase):
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        root = Path(tmp.name)
+        for target, name, value in (
+            (event_store, "DB_PATH", root / "events.sqlite3"),
+            (event_store, "_db_ready", False),
+            (panel, "CONFIG_PATH", root / "config.json"),
+            (panel, "_last_log_prune", [float("inf")]),
+        ):
+            patcher = mock.patch.object(target, name, value)
+            patcher.start()
+            self.addCleanup(patcher.stop)
+        self.client = panel.app.test_client()
+        for _ in range(202):
+            self.append()
+
+    def append(self, typ="PASS"):
+        return event_store.append_event({"type": typ, "host": "example.invalid", "method": "POST",
+                                         "dialog": "synthetic detail", "count": 1})
+
+    def get(self, **params):
+        response = self.client.get("/api/logs", query_string=params,
+                                   headers={"X-Shield-Token": panel.API_TOKEN})
+        self.assertEqual(response.status_code, 200)
+        return response.json
+
+    def test_backlog_and_new_writes_are_returned_without_gaps(self):
+        first = self.get(since=1, limit=200, slim=1)
+        self.assertEqual([e["seq"] for e in first["events"]], list(range(2, 202)))
+        self.assertTrue(first["has_more"])
+        self.assertEqual(first["next_since"], 201)
+        new_id = self.append()
+        second = self.get(since=first["next_since"], limit=200)
+        self.assertEqual([e["seq"] for e in second["events"]], [202, new_id])
+        self.assertFalse(second["has_more"])
+        self.assertTrue(all("dialog" not in e for e in first["events"]))
+
+    def test_initial_snapshot_and_default_store_query_still_show_latest(self):
+        first = self.get(limit=200)
+        self.assertEqual([e["seq"] for e in first["events"]], list(range(3, 203)))
+        self.assertFalse(first["has_more"])
+        self.assertEqual(first["next_since"], 202)
+        self.assertEqual([e["seq"] for e in event_store.fetch_events(limit=2)], [201, 202])
+
+    def test_filters_are_applied_before_pagination(self):
+        wanted = [self.append("MASK"), self.append("MASK")]
+        self.append("PASS")
+        first = self.get(since=1, limit=1, type="MASK", q="example.invalid")
+        self.assertEqual([e["seq"] for e in first["events"]], wanted[:1])
+        self.assertTrue(first["has_more"])
+        second = self.get(since=first["next_since"], limit=1, type="MASK", q="example.invalid")
+        self.assertEqual([e["seq"] for e in second["events"]], wanted[1:])
+        self.assertFalse(second["has_more"])
+
+    def test_empty_and_exactly_full_pages_do_not_claim_more_records(self):
+        exact = self.get(since=2, limit=200)
+        self.assertEqual(len(exact["events"]), 200)
+        self.assertFalse(exact["has_more"])
+        empty = self.get(since=exact["next_since"], limit=200)
+        self.assertEqual(empty["events"], [])
+        self.assertFalse(empty["has_more"])
+        self.assertEqual(empty["next_since"], 202)
+        # Oversized client limits must use the same cap for fetching and has_more.
+        for _ in range(1000):
+            self.append()
+        capped = self.get(since=1, limit=5000)
+        self.assertEqual(len(capped["events"]), 1000)
+        self.assertTrue(capped["has_more"])
+        self.assertEqual(capped["next_since"], 1001)


### PR DESCRIPTION
### 改动说明 / What does this PR do?

日志页切到后台一段时间后，如果积压超过 200 条，恢复轮询会跳过部分记录。例如页面已经看到序号 1，随后新增 2～202；原来会直接收到 3～202，并把游标推进到 202，序号 2 就无法再通过这条增量链取得。

这次让增量查询从最早未读记录开始分页，返回 `next_since` 和 `has_more`。前端每轮最多追赶 5 页，并支持请求取消；更多积压留给下一轮继续处理。首次加载仍显示最近记录，导出和其他数据库调用保留原有默认顺序。

### 影响范围 / Scope

- [x] SQLite 查询与日志 API
- [x] 前端日志轮询及接口类型

### 验证 / Validation

新增 4 项回归检查，覆盖积压期间继续写入、首次加载、筛选分页、空页、恰好满页和超过服务端上限的请求。也检查了 slim 响应不会带回正文详情。

本地 macOS / Python 3.13：539 项单元测试通过；Python 编译检查、流式和出口代理冒烟、前端构建、Lint、中英文字典对齐及版本一致性检查均通过。

### 自检 / Checklist

- [x] 未提交真实密钥、内网地址或个人数据
- [x] 未新增对外网络请求
- [x] 提交信息符合 Conventional Commits
- [x] 遵循项目 AGPL-3.0 开源许可
