### PR TITLE
fix: isolate SSE restoration by completion choice index

### DIFF
--- a/engine/transparent.py
+++ b/engine/transparent.py
@@ -3270,6 +3270,19 @@ def _restore_sse_data(data, sid, final=False, final_prefixes=()):
     # 非增量事件（message_start / content_block_start / response.completed …）是完整快照，整树还原
     for k, v in list(data.items()):
         data[k] = _restore_tree(v, sid, k)
+    # Responses .done payloads replace the full value, rather than extending
+    # its deltas. Discard that channel's stale tail after restoring the snapshot;
+    # appending it would duplicate text or emit a delta after completion.
+    snapshot = {
+        "response.output_text.done": ("text", "text"),
+        "response.reasoning_text.done": ("text", "reason"),
+        "response.function_call_arguments.done": ("arguments", "args"),
+    }.get(data.get("type"))
+    if snapshot is not None and isinstance(data.get(snapshot[0]), str):
+        channel = f"r{data.get('output_index', 0)}.{snapshot[1]}"
+        s = sessions.get(sid) or {}
+        s.get("pending", {}).pop(channel, None)
+        s.get("flush_tmpl", {}).pop(channel, None)
 
 
 def _build_flush_event(tmpl_json, channel, leftover):

--- a/engine/transparent.py
+++ b/engine/transparent.py
@@ -3161,6 +3161,11 @@ def _setter(obj, key):
     return _set
 
 
+def _sse_choice_index(choice, position):
+    index = choice.get("index")
+    return index if type(index) is int and index >= 0 else position
+
+
 def _sse_text_slots(data):
     """列出 SSE 事件里的增量文本槽位：[(channel, text, setter, escape)]。
 
@@ -3172,9 +3177,11 @@ def _sse_text_slots(data):
     if not isinstance(data, dict):
         return slots
     # OpenAI Chat Completions / Completions 流
-    for idx, c in enumerate(data.get("choices", []) or []):
+    for position, c in enumerate(data.get("choices", []) or []):
         if not isinstance(c, dict):
             continue
+        # Sparse chunks may each contain only one of several completion choices.
+        idx = _sse_choice_index(c, position)
         d = c.get("delta")
         if isinstance(d, dict):
             if isinstance(d.get("content"), str):
@@ -3230,27 +3237,30 @@ def _sse_text_slots(data):
     return slots
 
 
-def _sse_is_terminal(data):
-    """事件是否意味着某段输出到此为止（收尾前必须把缓冲吐净，否则吞字）。"""
+def _sse_terminal_prefixes(data):
+    """Channels ending in this event: None means all, () means none."""
     if not isinstance(data, dict):
-        return False
-    if data.get("type") in ("message_stop", "message_delta", "content_block_stop",
-                            "response.completed", "response.incomplete", "response.failed",
-                            "response.output_text.done"):
-        return True
-    for c in data.get("choices", []) or []:
-        if isinstance(c, dict) and c.get("finish_reason"):
-            return True
-    return False
+        return ()
+    if data.get("type") in ("message_stop", "message_delta", "response.completed",
+                            "response.incomplete", "response.failed"):
+        return None
+    if data.get("type") == "content_block_stop":
+        return (f"a{data.get('index', 0)}.",)
+    if data.get("type") == "response.output_text.done":
+        return (f"r{data.get('output_index', 0)}.text",)
+    return tuple(f"c{_sse_choice_index(c, position)}."
+                 for position, c in enumerate(data.get("choices", []) or [])
+                 if isinstance(c, dict) and c.get("finish_reason"))
 
 
-def _restore_sse_data(data, sid, final=False):
+def _restore_sse_data(data, sid, final=False, final_prefixes=()):
     """就地还原单个 SSE 事件的 JSON 负载。"""
     slots = _sse_text_slots(data)
     if slots:
         s = sessions.get(sid) or {}
         for channel, text, setter, escape in slots:
-            setter(restore(text, sid, channel=channel, escape=escape, final=final))
+            channel_final = final or final_prefixes is None or channel.startswith(final_prefixes)
+            setter(restore(text, sid, channel=channel, escape=escape, final=channel_final))
         # 只有真的留下半截占位符时才记模板（收尾补发用），正常路径零额外序列化
         pend = s.get("pending") or {}
         for channel, _t, _s, escape in slots:
@@ -3290,7 +3300,7 @@ def _build_flush_event(tmpl_json, channel, leftover):
     return prefix + "data: " + json.dumps(data, ensure_ascii=False) + "\n\n"
 
 
-def _flush_pending(sid):
+def _flush_pending(sid, channel_prefixes=None):
     """把各通道滞留的半截占位符补发出去，返回待追加的 SSE 文本。
 
     补发前必须先把 leftover 还原成原文（final=True 清空通道缓冲），
@@ -3305,20 +3315,24 @@ def _flush_pending(sid):
     tmpl = s.get("flush_tmpl") or {}
     out = []
     for channel, leftover in list(pend.items()):
-        if not leftover:
+        if channel_prefixes is not None and not channel.startswith(channel_prefixes):
             continue
         pend.pop(channel, None)  # 先取出，避免 restore 内部把自身 pending 再拼一遍
+        tmpl_json = tmpl.pop(channel, "")
+        if not leftover:
+            continue
         try:
-            restored = restore(leftover, sid, channel=channel, final=True)
+            slots = _sse_text_slots(json.loads(tmpl_json)) if tmpl_json else []
+            escape = next((slot[3] for slot in slots if slot[0] == channel), False)
+            restored = restore(leftover, sid, channel=channel, escape=escape, final=True)
         except Exception:
             restored = leftover
-        evt = _build_flush_event(tmpl.get(channel, ""), channel, restored)
+        evt = _build_flush_event(tmpl_json, channel, restored)
         if evt:
             out.append(evt)
         elif restored:
             # 没有可用模板（非流式回退路径等）：退化为裸文本，至少不丢字
             out.append(restored)
-    pend.clear()
     return "".join(out)
 
 
@@ -3349,13 +3363,16 @@ def _restore_sse_event(block, sid, final=False):
             except json.JSONDecodeError:
                 out_lines.append("data: " + restore(payload, sid, channel="raw", final=final))
                 continue
-            if _sse_is_terminal(data):
-                tail = _flush_pending(sid)
+            ending = _sse_terminal_prefixes(data)
+            # A terminal chunk can contain the final text fragment. Restore it
+            # before flushing, and leave other choices' partial tokens buffered.
+            _restore_sse_data(data, sid, final=final, final_prefixes=ending)
+            if ending is None or ending:
+                tail = _flush_pending(sid, channel_prefixes=ending)
                 if tail:
                     out_lines.append("")
                     out_lines.extend(tail.rstrip("\n").split("\n"))
                     out_lines.append("")
-            _restore_sse_data(data, sid, final=final)
             out_lines.append("data: " + json.dumps(data, ensure_ascii=False))
             continue
         out_lines.append(line)

--- a/tests/test_sse_choice_channels.py
+++ b/tests/test_sse_choice_channels.py
@@ -89,3 +89,39 @@ class SseChoiceChannelTests(unittest.TestCase):
                             for event in restored for item in event.get("choices", [])
                             for call in item.get("delta", {}).get("tool_calls", []))
         self.assertEqual(json.loads('"' + arguments + '"'), self.originals[1])
+
+    def test_responses_done_snapshots_clear_only_the_matching_channel(self):
+        cases = (("output_text", "text", "text", False),
+                 ("function_call_arguments", "arguments", "args", True),
+                 ("reasoning_text", "text", "reason", False))
+        for kind, field, channel, arguments in cases:
+            with self.subTest(kind=kind):
+                a, b = self.tokens
+                self.restore_events([
+                    {"type": f"response.{kind}.delta", "output_index": 4, "delta": b[:9]},
+                    {"type": "response.output_text.delta", "output_index": 9, "delta": a[:9]},
+                ])
+                snapshot = json.dumps({"name": b}) if arguments else b
+                done = {"type": f"response.{kind}.done", "output_index": 4, field: snapshot}
+                # Include the event header used by Responses clients, and check
+                # that no old delta is synthesized around the complete snapshot.
+                restored = tr._restore_sse_event(
+                    f"event: response.{kind}.done\ndata: " + json.dumps(done), self.sid)
+                self.assertEqual(restored.count("event: "), 1)
+                payloads = [json.loads(line[6:]) for line in restored.splitlines() if line.startswith("data: ")]
+                self.assertEqual(len(payloads), 1)
+                value = payloads[0][field]
+                self.assertEqual(json.loads(value) if arguments else value,
+                                 {"name": self.originals[1]} if arguments else self.originals[1])
+                session = tr.sessions[self.sid]
+                self.assertNotIn(f"r4.{channel}", session["pending"])
+                self.assertNotIn(f"r4.{channel}", session.get("flush_tmpl", {}))
+                self.assertEqual(session["pending"]["r9.text"], a[:9])
+                ending = self.restore_events([
+                    {"type": "response.output_text.delta", "output_index": 9, "delta": a[9:]},
+                    {"type": "response.completed", "response": {}}, "[DONE]",
+                ])
+                deltas = [d for d in ending if d.get("type", "").endswith(".delta")]
+                self.assertEqual(deltas, [{"type": "response.output_text.delta", "output_index": 9,
+                                           "delta": self.originals[0]}])
+                self.assertEqual(session["pending"], {})

--- a/tests/test_sse_choice_channels.py
+++ b/tests/test_sse_choice_channels.py
@@ -1,0 +1,91 @@
+"""Independent completion choices must keep independent restoration buffers."""
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "engine"))
+import transparent as tr
+
+
+def choice(index, text="", finish=None):
+    return {"index": index, "delta": {"content": text}, "finish_reason": finish}
+
+
+class SseChoiceChannelTests(unittest.TestCase):
+    def setUp(self):
+        for name in ("sessions", "_RECENT_FWD", "_RECENT_REV"):
+            patcher = mock.patch.object(tr, name, {})
+            patcher.start()
+            self.addCleanup(patcher.stop)
+        self.sid = "choice-test"
+        tr._new_session(self.sid)
+        self.tokens = ("{{NAME_bcdfgh}}", "{{NAME_jkmnpq}}")
+        self.originals = ("Alice Example", 'Bob "Example"\nSecond line')
+        tr.sessions[self.sid]["rev"].update(zip(self.tokens, self.originals))
+
+    def restore_events(self, events):
+        result = []
+        for data in events:
+            payload = data if isinstance(data, str) else json.dumps(data)
+            text = tr._restore_sse_event("data: " + payload, self.sid)
+            for line in text.splitlines():
+                if line.startswith("data: ") and line != "data: [DONE]":
+                    result.append(json.loads(line[6:]))
+        return result
+
+    def contents(self, events):
+        result = {}
+        for event in events:
+            for position, item in enumerate(event.get("choices", [])):
+                index = item.get("index", position)
+                result[index] = result.get(index, "") + item.get("delta", {}).get("content", "")
+        return result
+
+    def test_sparse_and_reordered_choices_restore_independently(self):
+        a, b = self.tokens
+        events = [
+            {"choices": [choice(4, a[:9])]},
+            {"choices": [choice(9, b[:9])]},
+            {"choices": [choice(9, b[9:]), choice(4, a[9:])]},
+            "[DONE]",
+        ]
+        self.assertEqual(self.contents(self.restore_events(events)),
+                         {4: self.originals[0], 9: self.originals[1]})
+
+    def test_one_choice_finishes_with_text_while_the_other_keeps_streaming(self):
+        a, b = self.tokens
+        events = [
+            {"choices": [choice(0, a[:9]), choice(1, b[:9])]},
+            {"choices": [choice(0, a[9:], "stop")]},
+            {"choices": [choice(1, b[9:], "stop")]},
+            "[DONE]",
+        ]
+        self.assertEqual(self.contents(self.restore_events(events)), dict(enumerate(self.originals)))
+        self.assertEqual(tr.sessions[self.sid]["pending"], {})
+
+    def test_finishing_choice_does_not_flush_another_choices_tool_arguments(self):
+        token = self.tokens[1]
+        def tool(piece):
+            return {"choices": [{"index": 1, "delta": {"tool_calls": [
+                {"index": 0, "function": {"arguments": piece}}]}}]}
+        events = [tool('{"name":"' + token[:9]), {"choices": [choice(0, "done", "stop")]},
+                  tool(token[9:] + '"}'), {"choices": [choice(1, finish="tool_calls")]}, "[DONE]"]
+        restored = self.restore_events(events)
+        arguments = "".join(call["function"].get("arguments", "")
+                            for event in restored for item in event.get("choices", [])
+                            for call in item.get("delta", {}).get("tool_calls", []))
+        self.assertEqual(json.loads(arguments), {"name": self.originals[1]})
+
+    def test_missing_index_and_final_partial_tokens_remain_compatible(self):
+        token = self.tokens[1]
+        # The model omitted the final braces. Flush must still JSON-escape the
+        # recovered value when the destination is a tool argument string.
+        events = [{"choices": [{"delta": {"tool_calls": [{"index": 0, "function": {
+            "arguments": token[:-2]}}]}}]}, "[DONE]"]
+        restored = self.restore_events(events)
+        arguments = "".join(call["function"].get("arguments", "")
+                            for event in restored for item in event.get("choices", [])
+                            for call in item.get("delta", {}).get("tool_calls", []))
+        self.assertEqual(json.loads('"' + arguments + '"'), self.originals[1])


### PR DESCRIPTION
### 改动说明 / What does this PR do?

同一请求包含多个候选回答时，每个流片段可能只带其中一个 choice。原来按片段数组位置建立还原通道，会让不同 `choice.index` 共用缓冲，交错的半截占位符因此拼到一起。

这次按有效的 `choice.index` 隔离通道，缺少编号时保留数组位置回退。结束事件只刷新对应通道，先处理事件自身携带的最后一段文本，避免一个候选结束时打断另一个。收尾补发工具参数时也保留 JSON 转义。

Responses 的正文、工具参数和思考文本 `.done` 事件携带完整值，会在还原后清理对应通道的旧缓冲及补发模板，避免结束时重复输出残留片段，同时保留其他通道仍在等待的内容。

### 影响范围 / Scope

- [x] 脱敏/还原引擎，已跑流式冒烟

### 验证 / Validation

新增 5 项回归检查，覆盖稀疏与重排片段、带最后文本的结束事件、其他候选仍在输出工具参数，以及缺少 index 和末尾花括号的兼容情况。补充检查三种 Responses 完整快照，确认没有额外的旧 delta、工具参数仍可解析为 JSON，且其他输出通道可以继续完成。

本地 macOS / Python 3.13：540 项单元测试通过；Python 编译检查、流式和出口代理冒烟、前端构建、Lint、中英文字典对齐及版本一致性检查均通过。使用本地模拟上游。

### 自检 / Checklist

- [x] 未提交真实密钥、内网地址或个人数据
- [x] 未新增对外网络请求
- [x] 提交信息符合 Conventional Commits
- [x] 遵循项目 AGPL-3.0 开源许可
