### PR TITLE
fix: preserve independent rule changes during queued saves

### DIFF
--- a/engine/panel.py
+++ b/engine/panel.py
@@ -3611,6 +3611,27 @@ def api_set_config():
                     "proxy_restarted": restarted})
 
 
+@app.post("/api/config/builtin_rules")
+def api_set_builtin_rules():
+    """Apply only the specified rule changes, without replacing a stale rule table."""
+    changes = request.get_json(silent=True)
+    if not isinstance(changes, dict) or not changes:
+        return jsonify({"ok": False, "error": "规则更新必须是非空 JSON 对象"}), 400
+    if any(rule not in DEFAULT_BUILTIN_RULES or type(enabled) is not bool
+           for rule, enabled in changes.items()):
+        return jsonify({"ok": False, "error": "规则名称必须有效，开关值必须是布尔值"}), 400
+    warnings = []
+    try:
+        with cfg_lock:
+            cfg = _load_config_locked()
+            cfg["builtin_rules"].update(changes)
+            cfg = save_config(cfg, warnings)
+    except Exception as e:
+        return jsonify({"ok": False, "error": _safe_public_text(e, 240)}), 400
+    _emit_log("[panel] 内置规则已更新")
+    return jsonify({"ok": True, "config": cfg, "warnings": warnings, "proxy_restarted": False})
+
+
 @app.get("/api/config/backups")
 def api_config_backups():
     """列出可用配置备份（config.json.bak-*），带结构摘要供用户判断该回滚到哪份。

--- a/frontend/src/api/settings.ts
+++ b/frontend/src/api/settings.ts
@@ -23,6 +23,14 @@ export function saveConfig(cfg: Partial<ShieldConfig>): Promise<SaveConfigRespon
   })
 }
 
+/** Update changed rules only; other tabs may have changed the remaining rules. */
+export function saveBuiltinRules(changes: Record<string, boolean>): Promise<SaveConfigResponse> {
+  return shieldFetch<SaveConfigResponse>('/api/config/builtin_rules', {
+    method: 'POST',
+    body: JSON.stringify(changes),
+  })
+}
+
 export function emergencyDisableOriginCheck(customToken?: string): Promise<{ ok: boolean; message: string; config?: ShieldConfig }> {
   return shieldFetch<{ ok: boolean; message: string; config?: ShieldConfig }>('/api/config/disable_origin_check', {
     method: 'POST',

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -33,7 +33,7 @@ import {
   Search,
   ChevronRight,
 } from 'lucide-react'
-import { getConfig, saveConfig, testUpstream, openDataDir, restoreNetwork, getHealth, getConfigBackups, restoreConfigBackup, getPriceSyncStatus, syncPricesNow, getPriceList, type ConfigBackup } from '@/api/settings'
+import { getConfig, saveConfig, saveBuiltinRules, testUpstream, openDataDir, restoreNetwork, getHealth, getConfigBackups, restoreConfigBackup, getPriceSyncStatus, syncPricesNow, getPriceList, type ConfigBackup, type SaveConfigResponse } from '@/api/settings'
 import { runAudit, cancelAudit, getAuditJob, getAuditReport } from '@/api/audit'
 import { getStatus } from '@/api/proxy'
 import { useMutation } from '@tanstack/react-query'
@@ -726,12 +726,12 @@ export default function SettingsPage({ embeddedTab }: { embeddedTab?: string } =
 
   const saveQueueRef = useRef<Promise<void>>(Promise.resolve())
 
-  const save = async (next: Partial<ShieldConfig>, msg?: string) => {
+  const save = async (next: Partial<ShieldConfig> | (() => Promise<SaveConfigResponse>), msg?: string) => {
     setSaving(true)
-    // 串行化保存请求队列：后一个保存必须等待前一个完成后执行，且总是从 queryClient 或返回结果获取最新状态
+    // 串行执行保存请求；规则开关只提交变化的条目，不携带旧的整表快照。
     const task = saveQueueRef.current.then(async () => {
       try {
-        const r = await saveConfig(next)
+        const r = await (typeof next === 'function' ? next() : saveConfig(next))
         if (!r.ok) {
           toast(r.error || t('settings.toast.saveFailed'), 'error')
           return
@@ -849,8 +849,7 @@ export default function SettingsPage({ embeddedTab }: { embeddedTab?: string } =
   }
 
   const setRule = (rule: string, on: boolean) => {
-    const builtin = (cfg?.builtin_rules as Record<string, boolean>) ?? {}
-    save({ builtin_rules: { ...builtin, [rule]: on } }, tf(on ? 'settings.toast.ruleOn' : 'settings.toast.ruleOff', { rule }))
+    save(() => saveBuiltinRules({ [rule]: on }), tf(on ? 'settings.toast.ruleOn' : 'settings.toast.ruleOff', { rule }))
   }
 
   const setSecret = (v: string[], msg?: string) => save({ secret_prefixes: v }, msg || t('settings.toast.prefixUpdated'))
@@ -1379,11 +1378,11 @@ export default function SettingsPage({ embeddedTab }: { embeddedTab?: string } =
               <div className="flex gap-1.5">
                 <Button size="sm" variant="outline" className="h-6 text-[11px]" onClick={() => {
                   const next = Object.fromEntries(Object.keys(builtinRules).map((r) => [r, true]))
-                  save({ builtin_rules: next }, t('settings.toast.allOn'))
+                  save(() => saveBuiltinRules(next), t('settings.toast.allOn'))
                 }}>{t('settings.words.allOn')}</Button>
                 <Button size="sm" variant="outline" className="h-6 text-[11px]" onClick={() => {
                   const next = Object.fromEntries(Object.keys(builtinRules).map((r) => [r, false]))
-                  save({ builtin_rules: next }, t('settings.toast.allOff'))
+                  save(() => saveBuiltinRules(next), t('settings.toast.allOff'))
                 }}>{t('settings.words.allOff')}</Button>
               </div>
             </CardHeader>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1376,11 +1376,11 @@ export default function SettingsPage({ embeddedTab }: { embeddedTab?: string } =
                 <p className="mt-0.5 text-[11px] text-muted-foreground">{t('settings.words.builtinRulesHint')}</p>
               </div>
               <div className="flex gap-1.5">
-                <Button size="sm" variant="outline" className="h-6 text-[11px]" onClick={() => {
+                <Button size="sm" variant="outline" className="h-6 text-[11px]" disabled={Object.keys(builtinRules).length === 0} onClick={() => {
                   const next = Object.fromEntries(Object.keys(builtinRules).map((r) => [r, true]))
                   save(() => saveBuiltinRules(next), t('settings.toast.allOn'))
                 }}>{t('settings.words.allOn')}</Button>
-                <Button size="sm" variant="outline" className="h-6 text-[11px]" onClick={() => {
+                <Button size="sm" variant="outline" className="h-6 text-[11px]" disabled={Object.keys(builtinRules).length === 0} onClick={() => {
                   const next = Object.fromEntries(Object.keys(builtinRules).map((r) => [r, false]))
                   save(() => saveBuiltinRules(next), t('settings.toast.allOff'))
                 }}>{t('settings.words.allOff')}</Button>

--- a/tests/test_atomic_rule_updates.py
+++ b/tests/test_atomic_rule_updates.py
@@ -1,0 +1,69 @@
+"""Rule changes from independent UI snapshots must not replace one another."""
+from concurrent.futures import ThreadPoolExecutor
+import sys
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "engine"))
+import panel
+
+
+class AtomicRuleUpdateTests(unittest.TestCase):
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        patcher = mock.patch.object(panel, "CONFIG_PATH", Path(tmp.name) / "config.json")
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        panel.save_config(panel.default_config())
+        self.headers = {"X-Shield-Token": panel.API_TOKEN}
+
+    def update(self, changes):
+        with panel.app.test_client() as client:
+            return client.post("/api/config/builtin_rules", json=changes, headers=self.headers)
+
+    def test_independent_rule_edits_preserve_both_changes(self):
+        before = panel.load_config()
+        for rule in ("EMAIL", "PHONE"):
+            response = self.update({rule: False})
+            self.assertEqual(response.status_code, 200)
+            self.assertFalse(response.json["proxy_restarted"])
+        after = panel.load_config()
+        self.assertFalse(after["builtin_rules"]["EMAIL"])
+        self.assertFalse(after["builtin_rules"]["PHONE"])
+        self.assertEqual(after["upstreams"], before["upstreams"])
+
+    def test_concurrent_edits_do_not_lose_updates(self):
+        barrier = threading.Barrier(2)
+        def edit(rule):
+            barrier.wait(timeout=5)
+            return self.update({rule: False}).status_code
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            self.assertEqual(list(pool.map(edit, ("EMAIL", "PHONE"))), [200, 200])
+        rules = panel.load_config()["builtin_rules"]
+        self.assertFalse(rules["EMAIL"])
+        self.assertFalse(rules["PHONE"])
+
+    def test_bulk_and_repeated_updates_are_supported_and_invalid_updates_are_atomic(self):
+        off = dict.fromkeys(panel.DEFAULT_BUILTIN_RULES, False)
+        self.assertEqual(self.update(off).status_code, 200)
+        self.assertEqual(panel.load_config()["builtin_rules"], off)
+        for value in (True, False, True):
+            self.assertEqual(self.update({"EMAIL": value}).status_code, 200)
+        expected = dict(off, EMAIL=True)
+        for invalid in ([], {}, {"EMAIL": False, "UNKNOWN_RULE": True}, {"EMAIL": "false"}, {"EMAIL": 0}):
+            with self.subTest(invalid=invalid):
+                self.assertEqual(self.update(invalid).status_code, 400)
+                self.assertEqual(panel.load_config()["builtin_rules"], expected)
+
+    def test_rule_endpoint_uses_existing_control_plane_guards(self):
+        with panel.app.test_client() as client:
+            for headers in ({}, {**self.headers, "Host": "example.invalid"},
+                            {**self.headers, "Origin": "https://example.invalid"}):
+                with self.subTest(headers=list(headers)):
+                    response = client.post("/api/config/builtin_rules", json={"EMAIL": False}, headers=headers)
+                    self.assertEqual(response.status_code, 403)
+        self.assertTrue(panel.load_config()["builtin_rules"]["EMAIL"])


### PR DESCRIPTION
### 改动说明 / What does this PR do?

连续修改不同规则时，保存队列虽然会依次发送请求，但请求里的整张规则表已经在入队前生成。如果两个操作使用同一旧快照，后一次成功保存会覆盖前一次修改；例如依次关闭 EMAIL 和 PHONE，最终 EMAIL 又恢复开启。

这次新增受现有控制面校验保护的 `/api/config/builtin_rules` 接口，只在配置锁内合并明确修改的规则。单项开关和全部开启/关闭都沿用原来的保存队列、结果反馈及缓存刷新，避免携带无关规则的旧值。配置尚未加载或没有可用规则时，全部开启/关闭按钮会禁用，避免发送空请求。原有整体配置接口保持兼容。

### 影响范围 / Scope

- [x] 控制面 / API
- [x] 前端规则设置与保存队列

### 验证 / Validation

新增 4 项回归检查，覆盖独立修改、并发保存、批量及重复修改、非法更新的原子拒绝，以及 Host / Origin / token 校验。

本地 macOS / Python 3.13：539 项单元测试通过；Python 编译检查、流式和出口代理冒烟、前端构建、Lint、中英文字典对齐及版本一致性检查均通过。

### 自检 / Checklist

- [x] 未提交真实密钥、内网地址或个人数据
- [x] 未新增对外网络请求
- [x] 提交信息符合 Conventional Commits
- [x] 遵循项目 AGPL-3.0 开源许可
